### PR TITLE
Fixes 01

### DIFF
--- a/config/chain_configs/seaice/seaice_A001.yml
+++ b/config/chain_configs/seaice/seaice_A001.yml
@@ -38,7 +38,6 @@ alg_area_filter:
 
 alg_flag_filters:
   surf_ocean_flag: 0
-  mcd_confident_flag: 0
 
 alg_crop_waveform:
   cropped_length: 128 

--- a/src/clev2er/algorithms/seaice/alg_area_filter.py
+++ b/src/clev2er/algorithms/seaice/alg_area_filter.py
@@ -201,7 +201,7 @@ class Algorithm(BaseAlgorithm):
         # filter the input parameter based on the area indices inside
         shared_dict["sat_lat"] = shared_dict["sat_lat"][indices_inside]
         shared_dict["sat_lon"] = shared_dict["sat_lon"][indices_inside]
-        shared_dict["measurements_time"] = shared_dict["measurement_time"][indices_inside]
+        shared_dict["measurement_time"] = shared_dict["measurement_time"][indices_inside]
         shared_dict["sat_altitude"] = shared_dict["sat_altitude"][indices_inside]
         shared_dict["window_delay"] = shared_dict["window_delay"][indices_inside]
         shared_dict["waveform"] = shared_dict["waveform"][indices_inside]

--- a/src/clev2er/algorithms/seaice/alg_flag_filters.py
+++ b/src/clev2er/algorithms/seaice/alg_flag_filters.py
@@ -176,7 +176,7 @@ class Algorithm(BaseAlgorithm):
         # filter the input parameter based on the area indices inside
         shared_dict["sat_lat"] = shared_dict["sat_lat"][combined_filter]
         shared_dict["sat_lon"] = shared_dict["sat_lon"][combined_filter]
-        shared_dict["measurements_time"] = shared_dict["measurement_time"][combined_filter]
+        shared_dict["measurement_time"] = shared_dict["measurement_time"][combined_filter]
         shared_dict["sat_altitude"] = shared_dict["sat_altitude"][combined_filter]
         shared_dict["window_delay"] = shared_dict["window_delay"][combined_filter]
         shared_dict["waveform"] = shared_dict["waveform"][combined_filter]

--- a/src/clev2er/algorithms/seaice/alg_flag_filters.py
+++ b/src/clev2er/algorithms/seaice/alg_flag_filters.py
@@ -5,7 +5,7 @@
     #Description of this Algorithm's purpose
     
     Filter records by discarding records which do not have the required flags:
-        measurement confidence flag = 0
+        least significant bit of measurement flag = 0
         surface type flag = 0
     
     #Main initialization (init() function) steps/resources required
@@ -14,13 +14,14 @@
 
     #Main process() function steps
 
-    Find index of the mcd_flag and surface_type arrays where both are 0.
-    Use the index to filter all arrays so that all records where both flags != 0 are removed.
+    Find index of mcd_flag array where value of least significant bit is 0
+    Find the index of surface_type array where value is 0.
+    Use the index to filter all arrays to remove unwanted records.
     
     #Contribution to shared_dict
 
-    shared_dict["flag_index"] (np.array[int]) : indices of area-filtered arrays that have mcd and
-                                                surface type flags == 0
+    shared_dict["flag_index"] (np.array[int]) : indices of area-filtered arrays that have correct 
+                                                mcd and surface type flags
 
     #Requires from shared_dict
 
@@ -98,7 +99,6 @@ class Algorithm(BaseAlgorithm):
         # --- Add your initialization steps below here ---
 
         self.surf_ocean_flag = self.config["alg_flag_filters"]["surf_ocean_flag"]
-        self.mcd_confident_flag = self.config["alg_flag_filters"]["mcd_confident_flag"]
 
         # --- End of initialization steps ---
 
@@ -140,8 +140,9 @@ class Algorithm(BaseAlgorithm):
         total_points = shared_dict["sat_lat"].size
 
         # filter by mcd_flag
-        # make a boolean index so we can combine later
-        mcd_index = shared_dict["mcd_flag"] == self.mcd_confident_flag
+        # if lsb is set, then mcd_flag is odd, even if unset -> can use %
+        # making a boolean index so we can combine later
+        mcd_index = (shared_dict["mcd_flag"] % 2) == 0
         num_confident = sum(mcd_index)  # find number of True values
 
         self.log.info(

--- a/src/clev2er/algorithms/seaice/tests/test_alg_area_filter.py
+++ b/src/clev2er/algorithms/seaice/tests/test_alg_area_filter.py
@@ -1,6 +1,7 @@
 """pytest for algorithm
     clev2er.algorithms.seaice.alg_area_filter
 """
+
 import logging
 import os
 from pathlib import Path
@@ -91,7 +92,7 @@ def test_area_filter() -> None:
     logger.info("Testing SIN file:")
     # load SARIn file
     l1b_sin_file = list(
-        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sar").glob("*.nc")
+        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sin").glob("*.nc")
     )[0]
     try:
         l1b = Dataset(l1b_sin_file)

--- a/src/clev2er/algorithms/seaice/tests/test_alg_crop_waveform.py
+++ b/src/clev2er/algorithms/seaice/tests/test_alg_crop_waveform.py
@@ -83,7 +83,7 @@ def test_crop_waveform() -> None:
     logger.info("Testing SIN file:")
     # load SARIn file
     l1b_sin_file = list(
-        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sar").glob("*.nc")
+        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sin").glob("*.nc")
     )[0]
     try:
         l1b = Dataset(l1b_sin_file)

--- a/src/clev2er/algorithms/seaice/tests/test_alg_flag_filters.py
+++ b/src/clev2er/algorithms/seaice/tests/test_alg_flag_filters.py
@@ -93,7 +93,7 @@ def test_flag_filters() -> None:
     logger.info("Testing SIN file:")
     # load SARIn file
     l1b_sin_file = list(
-        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sar").glob("*.nc")
+        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sin").glob("*.nc")
     )[0]
     try:
         l1b = Dataset(l1b_sin_file)

--- a/src/clev2er/algorithms/seaice/tests/test_alg_flag_filters.py
+++ b/src/clev2er/algorithms/seaice/tests/test_alg_flag_filters.py
@@ -76,11 +76,15 @@ def test_flag_filters() -> None:
         shared_dict["indices_flags"], ndarray
     ), "SAR - Flag indices not returned in shared_dict"
 
-    # check if mcd_flags only contains 0s
-    assert sum(shared_dict["mcd_flag"]) == 0, "SAR - Confidence flag contains non-zero values"
+    # check if mcd_flags only contains values for blocks which are not fatally degraded
+    assert (
+        sum((shared_dict["mcd_flag"]) % 2) == 0
+    ), "SIN - Confidence flag contain values for unusable measurements"
 
     # check if surface_type only contains 0s
-    assert sum(shared_dict["surface_type"]) == 0, "SAR - Surface type flag contains non-zero values"
+    assert (
+        sum(shared_dict["surface_type"]) == 0
+    ), "SAR - Surface type flag contains values for other surfaces"
 
     # check if all fields from the file have been filtered to the same size
     assert all(
@@ -114,15 +118,19 @@ def test_flag_filters() -> None:
         shared_dict["indices_flags"], ndarray
     ), "SIN - Flag indices not returned in shared_dict"
 
-    # check if mcd_flags only contains 0s
-    assert sum(shared_dict["mcd_flag"]) == 0, "SIN - Confidence flag contains non-zero values"
+    # check if mcd_flags only contains values for blocks which are not fatally degraded
+    assert (
+        sum((shared_dict["mcd_flag"]) % 2) == 0
+    ), "SIN - Confidence flag contain values for unusable measurements"
 
     # check if surface_type only contains 0s
-    assert sum(shared_dict["surface_type"]) == 0, "SIN - Surface type flag contains non-zero values"
+    assert (
+        sum(shared_dict["surface_type"]) == 0
+    ), "SIN - Surface type flag contains values for other surfaces"
 
     # check if all fields from the file have been filtered to the same size as sat_lat
-    assert all(
-        len(shared_dict["sat_lat"]) == len(val)
-        for key, val in shared_dict.items()
-        if isinstance(val, ndarray) and "indices" not in key
-    ), "SIN - Not all fields the same length"
+    for i, (key, val) in enumerate(shared_dict.items()):
+        if isinstance(val, ndarray) and "indices" not in key:
+            assert len(val) == len(
+                shared_dict["sat_lat"]
+            ), f"SIN - Shared_dict pair {i}: {key} not the same length as lat"

--- a/src/clev2er/algorithms/seaice/tests/test_alg_ingest_cs2.py
+++ b/src/clev2er/algorithms/seaice/tests/test_alg_ingest_cs2.py
@@ -59,8 +59,11 @@ def test_alg_ingest_cs2() -> None:
     except KeyError as exc:
         assert False, f"Could not initialize algorithm {exc}"
 
+    # ========================================================================================
     logger.info("Testing SAR file:")
+
     # load SAR file
+
     l1b_sar_file = list(
         (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sar").glob("*.nc")
     )[0]
@@ -81,10 +84,12 @@ def test_alg_ingest_cs2() -> None:
         len(shared_dict[ingested_fields[0]]) == len(shared_dict[key]) for key in ingested_fields
     ), "SAR - Not all fields the same length"
 
+    # ==============================================================================
     logger.info("Testing SIN file:")
+
     # load SARIn file
     l1b_sin_file = list(
-        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sar").glob("*.nc")
+        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sin").glob("*.nc")
     )[0]
     try:
         l1b = Dataset(l1b_sin_file)


### PR DESCRIPTION
Fixes to issues encountered in previous algorithms.

1. Flag filter and area filter had "measurement_time" misspelled and therefore wasn't being read or saved properly.
2. All tests were retesting SAR files when they should have been testing SIN files. 
3. MCD flag filter was looking for flag values that equaled 0. This was incorrect, as the MCD flag consists of several binary bits and only the least significant bit represents whether the waveform should be processed. The algorithm and test now checks if the LSB of the flag is 0, not if the value of the flag itself is 0.