### PR TITLE
Bp giles retracker

### DIFF
--- a/config/chain_configs/seaice/seaice_A001.yml
+++ b/config/chain_configs/seaice/seaice_A001.yml
@@ -65,5 +65,8 @@ alg_threshold_retrack:
   threshold_low: 0.3
   lew_max: 3.0
 
+alg_giles_retrack:
+  max_iterations: 3000
+
 # Resource Locators
 

--- a/src/clev2er/algorithms/seaice/alg_giles_retrack.py
+++ b/src/clev2er/algorithms/seaice/alg_giles_retrack.py
@@ -1,0 +1,168 @@
+""" clev2er.algorithms.seaice.alg_giles_retrack.py
+
+    Algorithm class module, used to implement a single chain algorithm
+
+    #Description of this Algorithm's purpose
+
+    Retracks specular waves using the gaussian plus exponential retracker, or Giles' retracker
+
+    #Main initialization (init() function) steps/resources required
+
+    If max_iterations has been set, use that value, else use the default value
+
+    #Main process() function steps
+
+    Get specular waves from waveform using specular_index
+    Get retracking points using retracker function
+    Save specular retracking points as lead_retracking_points
+
+    #Contribution to shared_dict
+
+    'lead_retracking_points' (npt.NDarray) : Retracking points found using this algorithm
+
+    #Requires from shared_dict
+
+    'waveform'
+    'specular_index'
+
+    Author: Ben Palmer
+    Date: 01 Mar 2024
+"""
+
+from typing import Tuple
+
+import numpy as np
+from codetiming import Timer
+from netCDF4 import Dataset  # pylint:disable=no-name-in-module
+
+from clev2er.algorithms.base.base_alg import BaseAlgorithm
+from clev2er.utils.cs2.retrackers.gaussian_exponential_retracker import (
+    gauss_plus_exp_tracker,
+)
+
+
+class Algorithm(BaseAlgorithm):
+    """CLEV2ER Algorithm class
+
+    contains:
+            .log (Logger) : log instance that must be used for all logging, set by BaseAlgorithm
+            .config (dict) : configuration dictionary, set by BaseAlgorithm
+
+        functions that need completing:
+            .init() : Algorithm initialization function (run once at start of chain)
+            .process(l1b,shared_dict) : Algorithm processing function (run on every L1b file)
+            .finalize() :   Algorithm finalization/closure function (run after all chain
+                            processing completed)
+
+        Inherits from BaseAlgorithm which handles interaction with the chain controller run_chain.py
+
+    """
+
+    def init(self) -> Tuple[bool, str]:
+        """Algorithm initialization function
+
+        Add steps in this function that are run once at the beginning of the chain
+        (for example loading a DEM or Mask)
+
+        Returns:
+            (bool,str) : success or failure, error string
+
+        Test for KeyError or OSError exceptions and raise them if found
+        rather than just returning (False,"error description")
+
+        Raises:
+            KeyError : for keys not found in self.config
+            OSError : for any file related errors
+
+        Note:
+        - retrieve required config data from self.config dict
+        - log using self.log.info(), or self.log.error() or self.log.debug()
+
+        """
+        self.alg_name = __name__
+        self.log.info("Algorithm %s initializing", self.alg_name)
+
+        # --- Add your initialization steps below here ---
+
+        self.max_iterations = self.config["alg_giles_retrack"]["max_iterations"]
+
+        # --- End of initialization steps ---
+
+        return (True, "")
+
+    @Timer(name=__name__, text="", logger=None)
+    def process(self, l1b: Dataset, shared_dict: dict) -> Tuple[bool, str]:
+        """Main algorithm processing function, called for every L1b file
+
+        Args:
+            l1b (Dataset): input l1b file dataset (constant)
+            shared_dict (dict): shared_dict data passed between algorithms. Use this dict
+                                to pass algorithm results down the chain or read variables
+                                set by other algorithms.
+
+        Returns:
+            Tuple : (success (bool), failure_reason (str))
+            ie
+            (False,'error string'), or (True,'')
+
+        Note:
+        - retrieve required config data from self.config dict (read-only)
+        - retrieve data from other algorithms from shared_dict
+        - add results,variables from this algorithm to shared_dict
+        - log using self.log.info(), or self.log.error() or self.log.debug()
+
+        """
+
+        # This step is required to support multi-processing. Do not modify
+        success, error_str = self.process_setup(l1b)
+        if not success:
+            return (False, error_str)
+
+        # -------------------------------------------------------------------
+        # Perform the algorithm processing, store results that need to be passed
+        # \/    down the chain in the 'shared_dict' dict     \/
+        # -------------------------------------------------------------------
+
+        specular_waves = shared_dict["waveform"][shared_dict["specular_index"]]
+
+        lead_retracking_points = np.apply_along_axis(
+            gauss_plus_exp_tracker, 1, specular_waves, max_iterations=self.max_iterations
+        )
+
+        num_nans = np.sum(np.isnan(lead_retracking_points))
+
+        self.log.info("Number of NaN values returned by retracker - %d", num_nans)
+
+        # If all retracking points are nans, skip file
+        if num_nans == lead_retracking_points.size:
+            return (False, "SKIP_OK")
+
+        shared_dict["lead_retracking_points"] = lead_retracking_points
+
+        # -------------------------------------------------------------------
+        # Returns (True,'') if success
+        return (success, error_str)
+
+    def finalize(self, stage: int = 0) -> None:
+        """Algorithm finalization function - called after all processing completed
+
+        Can be used to clean up/free resources initialized in the init() function
+
+        Args:
+            stage (int, optional):  this sets the stage when this function is called
+                                    by the chain controller. Useful during multi-processing.
+                                    Defaults to 0. Not normally used by Algorithms.
+        """
+        self.log.info(
+            "Finalize algorithm %s called at stage %d filenum %d",
+            self.alg_name,
+            stage,
+            self.filenum,
+        )
+        # ---------------------------------------------------------------------
+        # Add finalization steps here \/
+        # ---------------------------------------------------------------------
+
+        # None needed
+
+        # ---------------------------------------------------------------------

--- a/src/clev2er/algorithms/seaice/tests/test_alg_giles_retrack.py
+++ b/src/clev2er/algorithms/seaice/tests/test_alg_giles_retrack.py
@@ -1,0 +1,189 @@
+"""pytest for algorithm
+    clev2er.algorithms.seaice.alg_giles_retrack
+
+Author: Ben Palmer
+Date: 01 Mar 2024
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from netCDF4 import Dataset  # pylint:disable=no-name-in-module
+
+from clev2er.algorithms.seaice.alg_area_filter import Algorithm as AreaFilter
+from clev2er.algorithms.seaice.alg_crop_waveform import Algorithm as CropWaveform
+from clev2er.algorithms.seaice.alg_cs2_wave_discimination import (
+    Algorithm as WaveDiscrimination,
+)
+from clev2er.algorithms.seaice.alg_flag_filters import Algorithm as FlagFilter
+from clev2er.algorithms.seaice.alg_giles_retrack import Algorithm
+from clev2er.algorithms.seaice.alg_ingest_cs2 import Algorithm as IngestCS2
+from clev2er.algorithms.seaice.alg_pulse_peakiness import Algorithm as PulsePeakiness
+from clev2er.utils.config.load_config_settings import load_config_files
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def config() -> dict:
+    """Pytest fixture for the config dictionary
+
+    Returns:
+        dict: config dictionary
+    """
+    # load config
+    chain_config, _, _, _, _ = load_config_files("seaice")
+
+    # Set to Sequential Processing
+    chain_config["chain"]["use_multi_processing"] = False
+
+    return chain_config
+
+
+@pytest.fixture
+def previous_steps(
+    config: Dict,  # pylint: disable=redefined-outer-name
+) -> Dict:
+    """Pytest fixture for generating the previous steps needed to test the algorithm
+
+    Args:
+        config (dict): Config fixture
+
+    Returns:
+        Dict: Dictionary of previous steps
+    """
+    ## Initialise the previous chain steps (needed to test current step properly)
+    try:
+        chain_previous_steps = {
+            "ingest_cs2": IngestCS2(config, logger),  # no config used for this alg
+            "area_filter": AreaFilter(config, logger),
+            "flag_filter": FlagFilter(config, logger),
+            "crop_waveform": CropWaveform(config, logger),
+            "pulse_peakiness": PulsePeakiness(config, logger),
+            "wave_discrim": WaveDiscrimination(config, logger),
+        }
+    except KeyError as exc:
+        raise RuntimeError(f"Could not initialize previous steps in chain {exc}") from exc
+
+    return chain_previous_steps
+
+
+@pytest.fixture
+def thisalg(config: Dict) -> Algorithm:  # pylint: disable=redefined-outer-name
+    """Pytest fixture for the main algorithm being tested in this file
+
+    Args:
+        config (dict): Pytest fixture for the chain config
+
+    Returns:
+        Any: Returns the algorithm
+    """
+    # Initialise the Algorithm
+    try:
+        this_algo = Algorithm(config, logger)  # no config used for this alg
+    except KeyError as exc:
+        raise RuntimeError(f"Could not initialize algorithm {exc}") from exc
+
+    return this_algo
+
+
+def test_retrack_leads_sar(
+    previous_steps: Dict, thisalg: Algorithm  # pylint: disable=redefined-outer-name
+) -> None:
+    """test alg_giles_retrack.py for SAR waves
+
+    Test plan:
+    Load an SAR file
+    run Algorithm.process() on each
+    test that the files return (True, "")
+    """
+
+    base_dir = Path(os.environ["CLEV2ER_BASE_DIR"])
+    assert base_dir is not None
+
+    # ================================== SAR FILE TESTING ==========================================
+    logger.info("Testing SAR file:")
+
+    # load SAR file
+    l1b_sar_file = list(
+        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sar").glob("*.nc")
+    )[0]
+
+    try:
+        l1b = Dataset(l1b_sar_file)
+        logger.info("Loaded %s", l1b_sar_file)
+    except IOError:
+        assert False, f"{l1b_sar_file} could not be read"
+
+    shared_dict: Dict[str, Any] = {}
+
+    for title, step in previous_steps.items():
+        success, err_str = step.process(l1b, shared_dict)  # type: ignore[attr-defined]
+        if not success:
+            logger.error("SAR - Error with previous step: %s\n%s", title, err_str)
+
+    success, err_str = thisalg.process(l1b, shared_dict)
+
+    assert success, f"SAR - Algorithm failed due to: {err_str}"
+
+    # Algorithm tests
+    assert (
+        "lead_retracking_points" in shared_dict
+    ), "SAR - Shared_dict does not contain 'lead_retracking_points'"
+
+    lrp_dtype = shared_dict["lead_retracking_points"].dtype
+    assert (
+        "float" in str(lrp_dtype).lower()
+    ), f"SAR - Dtype of 'lead_retracking_points' is {lrp_dtype}, not float"
+
+
+def test_retrack_leads_sin(
+    previous_steps: Dict, thisalg: Algorithm  # pylint: disable=redefined-outer-name
+) -> None:
+    """test alg_giles_retrack.py for SIN waveforms
+
+    Test plan:
+    Load a SARIn file
+    run Algorithm.process() on each
+    test that the files return (True, "")
+    """
+
+    base_dir = Path(os.environ["CLEV2ER_BASE_DIR"])
+    assert base_dir is not None
+
+    # ================================== SIN FILE TESTING ==========================================
+
+    logger.info("Testing SIN file:")
+    # load SARIn file
+    l1b_sin_file = list(
+        (base_dir / "testdata" / "cs2" / "l1bfiles" / "arctic" / "sin").glob("*.nc")
+    )[0]
+    try:
+        l1b = Dataset(l1b_sin_file)
+        logger.info("Loaded %s", l1b_sin_file)
+    except IOError:
+        assert False, f"{l1b_sin_file} could not be read"
+
+    shared_dict: Dict[str, Any] = {}
+
+    for title, step in previous_steps.items():
+        success, err_str = step.process(l1b, shared_dict)  # type: ignore[attr-defined]
+        if not success:
+            logger.error("SIN - Error with previous step: %s\n%s", title, err_str)
+
+    success, err_str = thisalg.process(l1b, shared_dict)
+
+    assert success, f"SIN - Algorithm failed due to: {err_str}"
+
+    # Algorithm tests
+    assert (
+        "lead_retracking_points" in shared_dict
+    ), "SIN - Shared_dict does not contain 'lead_retracking_points'"
+
+    lrp_dtype = shared_dict["lead_retracking_points"].dtype
+    assert (
+        "float" in str(lrp_dtype).lower()
+    ), f"SIN - Dtype of 'lead_retracking_points' is {lrp_dtype}, not float"

--- a/src/clev2er/utils/cs2/retrackers/gaussian_exponential_retracker.py
+++ b/src/clev2er/utils/cs2/retrackers/gaussian_exponential_retracker.py
@@ -1,0 +1,88 @@
+"""Module for the gaussian plus exponential retracker (or Giles' retracker)
+
+gauss_plus_exp_tracker(): the retracking function which fits a gaussian plus exponential function
+    to the input waveform to find the retracking point.
+_GaussPlusExp(): the gaussian exponential function used by gauss_plus_exp_tracker
+
+Author: Ben Palmer
+Date: 01 Mar 2024
+"""
+
+import warnings
+
+import numpy as np
+import numpy.typing as npt
+from scipy.optimize import curve_fit
+
+
+def gauss_plus_exp_tracker(waveform: npt.NDArray, max_iterations: int = 3000) -> float:
+    """Gaussian plus exponential retracker, or Giles' retracker.
+
+    Retracks waveforms using a gaussian plus exponential function. Uses Levenberg-Marquardt
+    non-linear least-squares method to fit the function to the waveform. Returns the location of the
+    maximum amplitude of the fitted wave as the retracking point.
+
+    Args:
+        waveform (npt.NDArray): Input waveform
+
+    Raises:
+        RuntimeError: Raised if GaussPlusExp function encounters an error while fitting.
+
+    Returns:
+        float: The retracking point
+    """
+
+    warnings.simplefilter("ignore", RuntimeWarning, 84)
+
+    x: npt.NDArray = np.arange(waveform.size).astype(float)
+
+    x0: np.intp = np.argmax(waveform)
+    a: float = waveform[x0]
+
+    try:
+        popt, _ = curve_fit(  # pylint: disable=unbalanced-tuple-unpacking
+            _gauss_plus_exp, x, waveform[:], p0=[a, x0, 1, 1], maxfev=max_iterations, method="lm"
+        )
+    except RuntimeError:
+        return np.nan
+
+    if "popt" in locals():
+        tracking_point = popt[1]
+
+    return tracking_point
+
+
+def _gauss_plus_exp(x: npt.NDArray, a: float, x0: np.intp, k: float, sigma: float) -> npt.NDArray:
+    """Gaussian Plus Exponential distribution.
+
+    Args:
+        x (npt.NDArray): _description_
+        a (float): maximum amplitude of the distribution
+        x0 (np.intp): x when amplitude = maximum
+        k (float): rate of decay for the decaying exponential function
+        sigma (float): standard deviation of the Gaussian function
+
+    Returns:
+        npt.NDArray: The values of the funciton
+    """
+
+    xb = k * (sigma**2)
+    a2 = ((5 * k * sigma) - (4 * np.sqrt(k * xb))) / (2 * sigma * xb * np.sqrt(k * xb))
+    a3 = ((2 * np.sqrt(k * xb)) - (3 * k * sigma)) / (2 * sigma * (xb**2) * np.sqrt(k * xb))
+
+    y = np.piecewise(
+        x,
+        [x <= x0, (x > x0) & (x < (x0 + xb)), x > (x0 + xb)],
+        [
+            # linking function
+            lambda x: a * np.exp(-(((x - x0) / sigma) ** 2)),
+            # function to simulate the leading edge
+            lambda x: -((a3 * ((x - x0) ** 3) + a2 * ((x - x0) ** 2) + ((x - x0) / sigma)) ** 2),
+            # function to simulate the trailing edge
+            # NOTE: This is the one used in Giles et al from 2007. Tilling et al in 2017 has minor
+            # differences to this one, but the original is used here.
+            lambda x: a * np.exp(-(np.sqrt(k * (x - x0)) ** 2)),
+        ],
+    )
+
+    return y

--- a/src/clev2er/utils/cs2/retrackers/gaussian_exponential_retracker.py
+++ b/src/clev2er/utils/cs2/retrackers/gaussian_exponential_retracker.py
@@ -36,6 +36,8 @@ def gauss_plus_exp_tracker(waveform: npt.NDArray, max_iterations: int = 3000) ->
 
     x: npt.NDArray = np.arange(waveform.size).astype(float)
 
+    tracking_point = np.nan
+
     x0: np.intp = np.argmax(waveform)
     a: float = waveform[x0]
 
@@ -43,11 +45,9 @@ def gauss_plus_exp_tracker(waveform: npt.NDArray, max_iterations: int = 3000) ->
         popt, _ = curve_fit(  # pylint: disable=unbalanced-tuple-unpacking
             _gauss_plus_exp, x, waveform[:], p0=[a, x0, 1, 1], maxfev=max_iterations, method="lm"
         )
+        tracking_point = popt[1]  # Update tracking point if successful, otherwise returns NaN
     except RuntimeError:
-        return np.nan
-
-    if "popt" in locals():
-        tracking_point = popt[1]
+        pass
 
     return tracking_point
 

--- a/src/clev2er/utils/cs2/retrackers/tests/test_gauss_expo_retracker.py
+++ b/src/clev2er/utils/cs2/retrackers/tests/test_gauss_expo_retracker.py
@@ -1,0 +1,201 @@
+"""pytest for clev2er.utils.cs2.retrackers.gaussian_exponential_retracker.py
+
+Author: Ben Palmer
+Date: 01 Mar 2024
+"""
+
+# imports
+
+import logging
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from numpy._typing._array_like import NDArray
+
+from clev2er.utils.cs2.retrackers.gaussian_exponential_retracker import (
+    gauss_plus_exp_tracker,
+)
+
+# logging set up
+
+logger = logging.getLogger(__name__)
+
+# fixtures
+
+
+@pytest.fixture
+def test_waveform() -> npt.NDArray:
+    """Pytest fixture containing the test waveform
+
+    Returns:
+        npt.NDArray: test waveform
+    """
+    test_wave = np.asarray(
+        [
+            8.0,
+            11.0,
+            8.0,
+            12.0,
+            8.0,
+            11.0,
+            9.0,
+            14.0,
+            9.0,
+            15.0,
+            9.0,
+            17.0,
+            9.0,
+            19.0,
+            8.0,
+            22.0,
+            9.0,
+            24.0,
+            12.0,
+            28.0,
+            9.0,
+            31.0,
+            9.0,
+            35.0,
+            11.0,
+            39.0,
+            10.0,
+            51.0,
+            11.0,
+            55.0,
+            13.0,
+            68.0,
+            17.0,
+            82.0,
+            17.0,
+            110.0,
+            25.0,
+            135.0,
+            33.0,
+            193.0,
+            51.0,
+            285.0,
+            88.0,
+            474.0,
+            170.0,
+            873.0,
+            368.0,
+            2805.0,
+            1754.0,
+            18283.0,
+            65535.0,
+            49310.0,
+            10210.0,
+            6463.0,
+            2419.0,
+            1984.0,
+            1350.0,
+            1211.0,
+            775.0,
+            856.0,
+            558.0,
+            546.0,
+            530.0,
+            450.0,
+            376.0,
+            324.0,
+            340.0,
+            260.0,
+            222.0,
+            270.0,
+            252.0,
+            159.0,
+            143.0,
+            198.0,
+            158.0,
+            143.0,
+            161.0,
+            112.0,
+            133.0,
+            150.0,
+            173.0,
+            146.0,
+            153.0,
+            125.0,
+            126.0,
+            111.0,
+            118.0,
+            88.0,
+            108.0,
+            120.0,
+            101.0,
+            73.0,
+            89.0,
+            81.0,
+            90.0,
+            78.0,
+            99.0,
+            99.0,
+            126.0,
+            114.0,
+            111.0,
+            81.0,
+            88.0,
+            71.0,
+            73.0,
+            64.0,
+            53.0,
+            50.0,
+            44.0,
+            35.0,
+            42.0,
+            40.0,
+            41.0,
+            36.0,
+            36.0,
+            29.0,
+            38.0,
+            24.0,
+            29.0,
+            27.0,
+            31.0,
+            26.0,
+            31.0,
+            48.0,
+            53.0,
+            45.0,
+            37.0,
+            24.0,
+        ]
+    )
+
+    return test_wave
+
+
+# pytest
+
+
+def test_gauss_expo_retracker(
+    test_waveform: NDArray,  # pylint: disable=redefined-outer-name
+) -> None:
+    """pytest for the gauss_plus_exp_tracker function
+
+    Test plan:
+        Get test wave with known retracking point
+        Apply retracking function to find point
+        Test that type of result is correct
+        Test that result is correct
+
+    Args:
+        test_waveform (NDArray): pytest fixture for the input array
+
+    Returns:
+        None
+    """
+
+    logger.info("Testing gauss_plus_exp_tracker")
+
+    retracking_point = gauss_plus_exp_tracker(test_waveform)
+
+    assert isinstance(retracking_point, float), "Retracker does not return a float value"
+
+    # atol is larger here than other closeness checks, different devices return slightly different
+    # retracking values, but it should return a value be within range for this waveform
+    assert np.isclose(
+        retracking_point, 50.35911696865722, atol=0.5
+    ), "Retracker did not return a value close to what is expected"


### PR DESCRIPTION
Added Giles' retracker for retracking specular waves.

1. Added clev2er.utils.cs2.retrackers.gaussian_exponential_retracker for the main retracker function w/ test
2. Added clev2er.algorithms.seaice.alg_giles_retrack to apply the retracker to specular waves in the chain w/ test 

Applying the retracker function to the same waveform on different devices can return randomly different results. This also happened with the previous version of the processor, and is probably a symptom of the retracker function. 
