### PR TITLE
Bp merge mode changes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -41,6 +41,74 @@ files = [
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "astropy"
+version = "6.1.4"
+description = "Astronomy and astrophysics core library"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "astropy-6.1.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7954cdfea00445ed186431888ec8ab12d9e3adfdf316038c44009f57438e6389"},
+    {file = "astropy-6.1.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c0298f0e0d57cc61915a4438d54e47b4517ff6c7c5144ae4679077cfb0826d0b"},
+    {file = "astropy-6.1.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2491dc9a8f9c046b808995b2e3dc9ad8349c83042729b26c7907b5f7fbc53fd4"},
+    {file = "astropy-6.1.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22cc40cb137bbd777389d96871d84438537d01e1cd1dd1fc3dca374b4ece3200"},
+    {file = "astropy-6.1.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ec13a67ffac3d2b79ab2b725b16943133951cdd6833ab8941db798bc4de2da49"},
+    {file = "astropy-6.1.4-cp310-cp310-win32.whl", hash = "sha256:dbd7addf8c79d50e18eeef6c85aee7dd009f2e80756bc4d9b866592eeaca3577"},
+    {file = "astropy-6.1.4-cp310-cp310-win_amd64.whl", hash = "sha256:86e045e7ddfbfc500d015a9a6603be446c492c68fc019e69274b26e098aae50c"},
+    {file = "astropy-6.1.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:601d8a9a8d44f45064d2d8cc963cecf3949d3fbc10c9b6412c241cdc0c686b2c"},
+    {file = "astropy-6.1.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfc23b9e5e899f66f1377dc1116c247e6c7d0f92623ca115ad084a297414de03"},
+    {file = "astropy-6.1.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52683072d106162ca124e09f2f132de58ca9756e04c25ebd45d56cbdd6feb8f7"},
+    {file = "astropy-6.1.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50ab8d8097df76e33b56ab429d07240df6f273ccd267949ff99f8df79c7fcc42"},
+    {file = "astropy-6.1.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:81152825e80a03562cf2b95164c0ae7f56cd3521208a13221b3afa683c1469a6"},
+    {file = "astropy-6.1.4-cp311-cp311-win32.whl", hash = "sha256:af49e0a80ee6243727f449a6d8c99e711b2a4fdd1701d92c42964cd3e01a3490"},
+    {file = "astropy-6.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:b2fa9e1031eb83bee2d0b29f3e4d85a9d8b38ecb1b759a0ffbb8145fe8685d0e"},
+    {file = "astropy-6.1.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cf4ce31973dd18da522bb8f0fac91685ab1fcf21ca81251c79b09ef27d2b0d8f"},
+    {file = "astropy-6.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d4d10d964bfd110751fd47132af5227807d2beca85669b3d00d29cf5bae167d"},
+    {file = "astropy-6.1.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26c6cc099a312aaf0e473a4ea2ac4279f79ef53c8413e8259758d0f5930b4745"},
+    {file = "astropy-6.1.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3085e201e9d4bd223a543f7e2c0810dc873ea6a81bbdf06b5a987aa10e09bce"},
+    {file = "astropy-6.1.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1598720ac43875e602f1fe9766133ab67d50164047b5ed18f5e35d2fa69e914"},
+    {file = "astropy-6.1.4-cp312-cp312-win32.whl", hash = "sha256:59576f354772c448300438acc910b5a37b9d15ddfaa5c942746a7253a6c7765f"},
+    {file = "astropy-6.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:27496654ae2e672fa13eee9200caa776f47fbdce9ece55adcfe1d7e37e80341e"},
+    {file = "astropy-6.1.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:024cbba2b20d6abf50395669a010b1c026a0b966ba2292addd354163b0b44e55"},
+    {file = "astropy-6.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aeec3aa6c12f613b2609dfbf9bac355b5e64446e67643637ee449bdcf583f5e2"},
+    {file = "astropy-6.1.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1ed2dfb1551b2f140ca636c0156ab6a6a13f4202b7f3bc06fa739058f311d18"},
+    {file = "astropy-6.1.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa1a48e1dbd8072b3ef8a94334bc5344bf33bfd2b1b0236ca02eaa2cc3ca4b90"},
+    {file = "astropy-6.1.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b23cb881cf1fa0795b92ab2d86b04339a0a38b336e3a391fd050b6caf695b01b"},
+    {file = "astropy-6.1.4-cp313-cp313-win32.whl", hash = "sha256:b28752d9515dac72358bce58214ef4bae89bfc4af548c98f6052ff91b38e93ee"},
+    {file = "astropy-6.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:048ae0883db33f94dea03800211d2e4a0aacaf8d0f0640196815d9d1298b7449"},
+    {file = "astropy-6.1.4.tar.gz", hash = "sha256:361558e2b093a99bebe69f1fd47fac86a192607a4c16ed39ba0a800b2ab60c34"},
+]
+
+[package.dependencies]
+astropy-iers-data = ">=0.2024.8.27.10.28.29"
+numpy = ">=1.23"
+packaging = ">=19.0"
+pyerfa = ">=2.0.1.1"
+PyYAML = ">=3.13"
+
+[package.extras]
+all = ["asdf-astropy (>=0.3)", "astropy[recommended]", "astropy[typing]", "beautifulsoup4", "bleach", "bottleneck", "certifi", "dask[array]", "fsspec[http] (>=2023.4.0)", "h5py", "html5lib", "ipython (>=4.2)", "jplephem", "mpmath", "pandas", "pre-commit", "pyarrow (>=7.0.0)", "pytest (>=7.0)", "pytz", "s3fs (>=2023.4.0)", "sortedcontainers"]
+docs = ["Jinja2 (>=3.1.3)", "astropy[recommended]", "matplotlib (>=3.9.1)", "numpy (<2.0)", "pytest (>=7.0)", "sphinx", "sphinx-astropy[confv2] (>=1.9.1)", "sphinx-changelog (>=1.2.0)", "sphinx-design", "sphinxcontrib-globalsubs (>=0.1.1)", "tomli"]
+recommended = ["matplotlib (>=3.5.0,!=3.5.2)", "scipy (>=1.8)"]
+test = ["pytest (>=7.0)", "pytest-astropy (>=0.10)", "pytest-astropy-header (>=0.2.1)", "pytest-doctestplus (>=0.12)", "pytest-xdist", "threadpoolctl"]
+test-all = ["array-api-strict", "astropy[test]", "coverage[toml]", "ipython (>=4.2)", "objgraph", "sgp4 (>=2.3)", "skyfield (>=1.20)"]
+typing = ["typing-extensions (>=4.0.0)"]
+
+[[package]]
+name = "astropy-iers-data"
+version = "0.2024.10.21.0.33.21"
+description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "astropy_iers_data-0.2024.10.21.0.33.21-py3-none-any.whl", hash = "sha256:9cb267aff398c2846e38afe7ef09c6d65866c47334064040f8d95aa770f51d99"},
+    {file = "astropy_iers_data-0.2024.10.21.0.33.21.tar.gz", hash = "sha256:d37b1cf3d5d986490b80cddc894715bfea728e8cf93e260c60702696d2b41452"},
+]
+
+[package.extras]
+docs = ["pytest"]
+test = ["hypothesis", "pytest", "pytest-remotedata"]
+
+[[package]]
 name = "attrs"
 version = "23.2.0"
 description = "Classes Without Boilerplate"
@@ -1458,6 +1526,33 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "pyerfa"
+version = "2.0.1.4"
+description = "Python bindings for ERFA"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pyerfa-2.0.1.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ff112353944bf705342741f2fe41674f97154a302b0295eaef7381af92ad2b3a"},
+    {file = "pyerfa-2.0.1.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:900b266a3862baa9560d6b1b184dcc14e0e76d550ff70d32336d3989b2ed18ca"},
+    {file = "pyerfa-2.0.1.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:610d2bc314e140d876b93b1287c7c81685434873c8700cc3e1596193f77d1071"},
+    {file = "pyerfa-2.0.1.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e4508dd7ffd7b27b7f67168643764454887e990ca9e4584824f0e3ab5884c0f"},
+    {file = "pyerfa-2.0.1.4-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:83a44ba84ebfc3244412ecbf1065c087c382da84f1c3eee1f2a0638d9046ac96"},
+    {file = "pyerfa-2.0.1.4-cp39-abi3-win32.whl", hash = "sha256:46d3bed0ac666f08d8364b34a00b8c6595358d6c4f4532da8d13fac0e5227baa"},
+    {file = "pyerfa-2.0.1.4-cp39-abi3-win_amd64.whl", hash = "sha256:bc3cf45967ac1af77a777deb050fb08bbc75256dd97ca6005e4d385358b7af40"},
+    {file = "pyerfa-2.0.1.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:88a8d0f3608a66871615bd168fcddf674dce9f7568c239a03cf8d9936161d032"},
+    {file = "pyerfa-2.0.1.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9045e9f786c76cb55da86ada3405c378c32b88f6e3c6296cb288496ab374b068"},
+    {file = "pyerfa-2.0.1.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:39cf838c9a21e40d4e3183bead65b3ce6af763c4a727f87d84909c9be7d3a33c"},
+    {file = "pyerfa-2.0.1.4.tar.gz", hash = "sha256:acb8a6713232ea35c04bc6e40ac4e461dfcc817d395ef2a3c8051c1a33249dd3"},
+]
+
+[package.dependencies]
+numpy = ">=1.19"
+
+[package.extras]
+docs = ["sphinx-astropy (>=1.3)"]
+test = ["pytest", "pytest-doctestplus (>=0.7)"]
+
+[[package]]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2279,4 +2374,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "39518b4f4db81a8b7e8f0d3f94c3e8ef08f23f28c7013073284180580ff068d2"
+content-hash = "5a1fd73dcf76fde5d076afe93c12d42dbe6a13aa71d3e0922601347f263ff523"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ xmltodict = "^0.13.0"
 cartopy = "^0.22.0"
 scikit-image = "^0.22.0"
 scikit-learn = "^1.5.0"
+astropy = "^6.1.4"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/clev2er/algorithms/seaice_stage_1/alg_add_si_conc.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_add_si_conc.py
@@ -53,7 +53,7 @@ Date: 01 Mar 2024
 
 import glob
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Tuple
 
 import numpy as np
@@ -172,7 +172,7 @@ class Algorithm(BaseAlgorithm):
         for wv_num, (wv_timestamp, wv_lat, wv_lon) in enumerate(
             zip(shared_dict["measurement_time"], shared_dict["sat_lat"], shared_dict["sat_lon"])
         ):
-            file_date = datetime.fromtimestamp(wv_timestamp).strftime("%Y%m%d")
+            file_date = datetime.fromtimestamp(wv_timestamp, tz=timezone.utc).strftime("%Y%m%d")
 
             if self.most_recent_file["date"] == file_date:
                 # If date is the same as the most recent file date, get values from dict

--- a/src/clev2er/algorithms/seaice_stage_1/alg_area_filter.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_area_filter.py
@@ -192,6 +192,7 @@ class Algorithm(BaseAlgorithm):
         shared_dict["sat_lat"] = shared_dict["sat_lat"][indices_inside]
         shared_dict["sat_lon"] = shared_dict["sat_lon"][indices_inside]
         shared_dict["measurement_time"] = shared_dict["measurement_time"][indices_inside]
+        shared_dict["andy_time"] = shared_dict["andy_time"][indices_inside]
         shared_dict["block_number"] = shared_dict["block_number"][indices_inside]
         shared_dict["packet_count"] = shared_dict["packet_count"][indices_inside]
         shared_dict["sat_altitude"] = shared_dict["sat_altitude"][indices_inside]

--- a/src/clev2er/algorithms/seaice_stage_1/alg_flag_filters.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_flag_filters.py
@@ -178,6 +178,7 @@ class Algorithm(BaseAlgorithm):
         shared_dict["sat_lat"] = shared_dict["sat_lat"][combined_filter]
         shared_dict["sat_lon"] = shared_dict["sat_lon"][combined_filter]
         shared_dict["measurement_time"] = shared_dict["measurement_time"][combined_filter]
+        shared_dict["andy_time"] = shared_dict["andy_time"][combined_filter]
         shared_dict["block_number"] = shared_dict["block_number"][combined_filter]
         shared_dict["packet_count"] = shared_dict["packet_count"][combined_filter]
         shared_dict["sat_altitude"] = shared_dict["sat_altitude"][combined_filter]

--- a/src/clev2er/algorithms/seaice_stage_1/alg_ingest_cs2.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_ingest_cs2.py
@@ -62,11 +62,12 @@ shared_dict["surface_type"] (np.array[int]) : array of surface type flags
 None
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import partial
 from typing import Tuple
 
 import numpy as np
+from astropy.time import Time, TimeDelta
 from codetiming import Timer  # used to time the Algorithm.process() function
 from netCDF4 import Dataset  # pylint:disable=no-name-in-module
 
@@ -182,12 +183,11 @@ class Algorithm(BaseAlgorithm):
         # convert longitude to 0..360 (from -180,180)
         shared_dict["sat_lon"] = l1b["lon_20_ku"][:].data % 360.0  #
         # timestamps in file are seconds from 1/1/2000, convert to seconds from 1/1/1970
-        shared_dict["measurement_time"] = np.asarray(
-            [
-                (datetime(2000, 1, 1, 0, 0, 0, 0) + timedelta(seconds=x)).timestamp()
-                for x in l1b["time_20_ku"][:].data
-            ]
-        )
+        # Using astropy's Time and TimeDelta to keep TAI scale from source data
+        start_epoch = Time(datetime(2000, 1, 1), format="datetime", scale="tai")
+        shared_dict["measurement_time"] = (
+            start_epoch + TimeDelta(l1b["time_20_ku"][:].data, format="sec")
+        ).tai.unix_tai
 
         # trying to recreate andy's time
         days: np.ndarray = l1b["time_20_ku"][:].data // 86400

--- a/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
@@ -161,7 +161,7 @@ class Algorithm(BaseAlgorithm):
             return (False, "VarLengthError")
 
         # Create output file locations
-        output_file_name = f"merge_{l1b.rel_orbit_number:04d}.nc"
+        output_file_name = f"merge_{l1b.abs_orbit_number:06d}.nc"
         output_file_path = os.path.join(self.merge_file_dir, output_file_name)
 
         # If output file does not already exist, create new file
@@ -173,6 +173,7 @@ class Algorithm(BaseAlgorithm):
             output_nc.createVariable("packet_count", "i4", ("n_samples",), compression="zlib")
             output_nc.createVariable("block_number", "i4", ("n_samples",), compression="zlib")
             output_nc.createVariable("measurement_time", "f8", ("n_samples",), compression="zlib")
+            output_nc.createVariable("andy_time", "f8", ("n_samples",), compression="zlib")
             output_nc.createVariable("sat_lat", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("sat_lon", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("elevation", "f4", ("n_samples",), compression="zlib")
@@ -186,6 +187,7 @@ class Algorithm(BaseAlgorithm):
         measurement_time = np.concatenate(
             (output_nc["measurement_time"][:], shared_dict["measurement_time"])
         )
+        andy_time = np.concatenate((output_nc["andy_time"][:], shared_dict["andy_time"]))
         sat_lat = np.concatenate((output_nc["sat_lat"][:], shared_dict["sat_lat"]))
         sat_lon = np.concatenate((output_nc["sat_lon"][:], shared_dict["sat_lon"]))
         elevation = np.concatenate((output_nc["elevation"][:], shared_dict["elevation"]))
@@ -197,6 +199,7 @@ class Algorithm(BaseAlgorithm):
         output_nc["packet_count"][:] = packet_count
         output_nc["block_number"][:] = block_number
         output_nc["measurement_time"][:] = measurement_time
+        output_nc["andy_time"][:] = andy_time
         output_nc["sat_lat"][:] = sat_lat
         output_nc["sat_lon"][:] = sat_lon
         output_nc["elevation"][:] = elevation

--- a/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
@@ -162,6 +162,12 @@ class Algorithm(BaseAlgorithm):
 
         # Create output file locations
         output_file_name = f"merge_{l1b.abs_orbit_number:06d}.nc"
+        output_dir = os.path.join(
+            self.merge_file_dir, l1b.creation_time[4:8], l1b.creation_time[9:11]
+        )
+        if not (os.path.exists(output_dir) and os.path.isdir(output_dir)):
+            self.log.info("Creating directory %s", output_dir)
+            os.makedirs(output_dir)
         output_file_path = os.path.join(self.merge_file_dir, output_file_name)
 
         # If output file does not already exist, create new file
@@ -178,6 +184,7 @@ class Algorithm(BaseAlgorithm):
             output_nc.createVariable("sat_lon", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("elevation", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("lead_floe_class", "f4", ("n_samples",), compression="zlib")
+            output_nc.createVariable("seaice_conc", "f4", ("n_samples",), compression="zlib")
         else:
             output_nc = Dataset(output_file_path, mode="a")
 
@@ -194,6 +201,9 @@ class Algorithm(BaseAlgorithm):
         lead_floe_class = np.concatenate(
             (output_nc["lead_floe_class"][:], shared_dict["lead_floe_class"])
         )
+        seaice_conc = np.concatenate(
+            (output_nc["seaice_conc"][:], shared_dict["seaice_concentration"])
+        )
 
         # add the data to the merge file
         output_nc["packet_count"][:] = packet_count
@@ -204,6 +214,7 @@ class Algorithm(BaseAlgorithm):
         output_nc["sat_lon"][:] = sat_lon
         output_nc["elevation"][:] = elevation
         output_nc["lead_floe_class"][:] = lead_floe_class
+        output_nc["seaice_conc"][:] = seaice_conc
 
         # close file
         output_nc.close()

--- a/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
@@ -172,7 +172,7 @@ class Algorithm(BaseAlgorithm):
 
             output_nc.createVariable("packet_count", "i4", ("n_samples",), compression="zlib")
             output_nc.createVariable("block_number", "i4", ("n_samples",), compression="zlib")
-            output_nc.createVariable("measurement_time", "f4", ("n_samples",), compression="zlib")
+            output_nc.createVariable("measurement_time", "f8", ("n_samples",), compression="zlib")
             output_nc.createVariable("sat_lat", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("sat_lon", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("elevation", "f4", ("n_samples",), compression="zlib")

--- a/src/clev2er/algorithms/seaice_stage_1/tests/test_alg_ingest_cs2.py
+++ b/src/clev2er/algorithms/seaice_stage_1/tests/test_alg_ingest_cs2.py
@@ -30,6 +30,7 @@ def test_alg_ingest_cs2() -> None:
         "sat_lat",
         "sat_lon",
         "measurement_time",
+        "andy_time",
         "sat_altitude",
         "window_delay",
         "waveform",


### PR DESCRIPTION
Some changes related to the merge mode algorithm.

- Added a new time variable which mimics the one used in the original chain. 
    - It might be possible to use a function to generate these values from the time variable already in the file, but wanted to original file data to make sure it's accurate. The original stores time as [number of days since 1950]
- Added Astropy to use Time and TimeDelta classes.
    - I didn't realise that the time stored in the files are TAI time which has some differences compared to Unix time. TAI accounts for leap seconds, while Unix doesn't. This was causing an issue when comparing files and may also have issues when reading external files. 
- Changed format of time variable in merge file from 'f4' to 'f8'. 
    - When concatenating the data from the current file and the data stored in the file, there was a memory error and thousands of records would equal the same timestamp. Increasing the number of bits for the variable prevented this.
- Added sea ice concentration to merge files
    - Just for testing, not necessary for the chain.
- Merge files now go into a subdirectory within the main merge directory for their respective year and month