### PR TITLE
Validity index

### DIFF
--- a/src/clev2er/algorithms/seaice_stage_1/alg_cs2_wave_discrimination.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_cs2_wave_discrimination.py
@@ -186,6 +186,11 @@ class Algorithm(BaseAlgorithm):
         shared_dict["specular_index"] = np.where(specular_waves)[0]
         shared_dict["diffuse_index"] = np.where(diffuse_waves)[0]
 
+        # Making a validity variable, 0=Invalid 1=Valid
+        shared_dict["valid"] = np.ones(shape=shared_dict["measurement_time"].shape, dtype=bool)
+        # set all unknown values to invalid
+        shared_dict["valid"][shared_dict["lead_floe_class"] == 0] = False
+
         self.log.info("Class counts")
         for v in set([0, 1, 2, 3]).union(np.unique(shared_dict["lead_floe_class"])):
             self.log.info("\t %d - %5d", v, sum(shared_dict["lead_floe_class"] == v))

--- a/src/clev2er/algorithms/seaice_stage_1/alg_elev_calculations.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_elev_calculations.py
@@ -40,7 +40,7 @@ Save elevations to dict.
 'pole_tide'
 'specular_index'
 'diffuse_index'
-'idx_lew_lt_max'
+'idx_lew_gt_max'
 'lead_retracking_points'
 'floe_retracking_points'
 'bin_shift'
@@ -159,9 +159,7 @@ class Algorithm(BaseAlgorithm):
 
         retracking_points = np.zeros(shared_dict["sat_lat"].size) * np.nan
         retracking_points[shared_dict["specular_index"]] = shared_dict["lead_retracking_points"]
-        retracking_points[
-            shared_dict["diffuse_index"][shared_dict["idx_lew_lt_max"]]
-        ] = shared_dict["floe_retracking_points"]
+        retracking_points[shared_dict["diffuse_index"]] = shared_dict["floe_retracking_points"]
 
         # do bin_width * bin_shift here since it will all be subtracted from the elevation
         retracker_correction = self.bin_width * (
@@ -185,6 +183,9 @@ class Algorithm(BaseAlgorithm):
             sum(np.isnan(elevations)),
         )
         shared_dict["elevation"] = elevations
+
+        shared_dict["valid"][shared_dict["diffuse_index"][shared_dict["idx_lew_gt_max"]]] = False
+        shared_dict["valid"][shared_dict["diffuse_index"][shared_dict["idx_lew_gt_max"]]] = False
 
         # -------------------------------------------------------------------
         # Returns (True,'') if success

--- a/src/clev2er/algorithms/seaice_stage_1/alg_giles_retrack.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_giles_retrack.py
@@ -146,14 +146,16 @@ class Algorithm(BaseAlgorithm):
             | (fit_sigmas < 0.00001)
         )
 
-        lead_retracking_points[bad_fits] = np.nan
+        # set all retracking points to invalid
+        # lead_retracking_points[bad_fits] = np.nan
+        shared_dict["valid"][shared_dict["specular_index"][bad_fits]] = False
 
-        num_nans = np.sum(np.isnan(lead_retracking_points))
+        num_bad_fits = np.sum(bad_fits)
 
-        self.log.info("Number of NaN values returned by retracker - %d", num_nans)
+        self.log.info("Number of bad fits returned by retracker - %d", num_bad_fits)
 
-        # If all retracking points are nans, skip file
-        if num_nans == lead_retracking_points.size:
+        # If all retracking points are bad fits, skip file
+        if num_bad_fits == lead_retracking_points.size:
             return (False, "SKIP_OK")
 
         shared_dict["lead_retracking_points"] = lead_retracking_points

--- a/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_merge_modes.py
@@ -144,6 +144,7 @@ class Algorithm(BaseAlgorithm):
             == shared_dict["sat_lon"].size
             == shared_dict["elevation"].size
             == shared_dict["lead_floe_class"].size
+            == shared_dict["valid"].size
         ):
             self.log.error("Variables that will be added to merge file are not of equal length")
 
@@ -155,6 +156,7 @@ class Algorithm(BaseAlgorithm):
                 "sat_lon",
                 "elevation",
                 "lead_floe_class",
+                "valid",
             ]:
                 self.log.error("   %s - size=%d", var_name, shared_dict[var_name].size)
 
@@ -177,6 +179,7 @@ class Algorithm(BaseAlgorithm):
             output_nc.createVariable("sat_lon", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("elevation", "f4", ("n_samples",), compression="zlib")
             output_nc.createVariable("lead_floe_class", "f4", ("n_samples",), compression="zlib")
+            output_nc.createVariable("valid", "b", ("n_samples",), compression="zlib")
         else:
             output_nc = Dataset(output_file_path, mode="a")
 
@@ -192,6 +195,7 @@ class Algorithm(BaseAlgorithm):
         lead_floe_class = np.concatenate(
             (output_nc["lead_floe_class"][:], shared_dict["lead_floe_class"])
         )
+        valid = np.concatenate((output_nc["valid"][:], shared_dict["valid"]))
 
         # add the data to the merge file
         output_nc["packet_count"][:] = packet_count
@@ -201,6 +205,7 @@ class Algorithm(BaseAlgorithm):
         output_nc["sat_lon"][:] = sat_lon
         output_nc["elevation"][:] = elevation
         output_nc["lead_floe_class"][:] = lead_floe_class
+        output_nc["valid"][:] = valid
 
         # close file
         output_nc.close()

--- a/src/clev2er/algorithms/seaice_stage_1/alg_threshold_retrack.py
+++ b/src/clev2er/algorithms/seaice_stage_1/alg_threshold_retrack.py
@@ -22,8 +22,8 @@ Generate index of which samples have a LEW less than the limit
 #Contribution to shared_dict
 
 shared_dict["floe_retracking_points"] (np.ndarray[float]) : array of retracking points for floes
-shared_dict["idx_lew_lt_max"] (np.ndarray[int]) :   index array of samples with leading edge
-                                                    width less than limit
+shared_dict["idx_lew_gt_max"] (np.ndarray[int]) :   index array of samples with leading edge
+                                                    width greater than limit
 
 #Requires from shared_dict
 
@@ -149,16 +149,15 @@ class Algorithm(BaseAlgorithm):
         lews = np.abs(points_higher - points_lower)
 
         # only keep points with leading edge width < max value
-        idx_lew_lt_max = np.where(lews < self.lew_max)[0]
-        points_higher = points_higher[idx_lew_lt_max]
+        idx_lew_gt_max = np.where(lews > self.lew_max)[0]
 
         self.log.info(
             "Number of samples that exceeded LEW limit - %d",
-            shared_dict["waveform_smooth"].shape[0] - idx_lew_lt_max.size,
+            shared_dict["waveform_smooth"].shape[0] - idx_lew_gt_max.size,
         )
 
         shared_dict["floe_retracking_points"] = points_higher
-        shared_dict["idx_lew_lt_max"] = idx_lew_lt_max
+        shared_dict["idx_lew_gt_max"] = idx_lew_gt_max
 
         # -------------------------------------------------------------------
         # Returns (True,'') if success

--- a/src/clev2er/algorithms/seaice_stage_1/tests/test_alg_merge_modes.py
+++ b/src/clev2er/algorithms/seaice_stage_1/tests/test_alg_merge_modes.py
@@ -124,9 +124,6 @@ def test_merge_modes(
     Load an SAR file
     run Algorithm.process() on each
     test that the files return (True, "")
-
-    FILL THIS OUT WITH STEPS
-
     """
 
     base_dir = Path(os.environ["CLEV2ER_BASE_DIR"])

--- a/src/clev2er/algorithms/seaice_stage_1/tests/test_alg_threshold_retrack.py
+++ b/src/clev2er/algorithms/seaice_stage_1/tests/test_alg_threshold_retrack.py
@@ -158,12 +158,12 @@ def test_retrack_floes_sar(
         & (shared_dict["floe_retracking_points"] < shared_dict["waveform"].shape[1])
     ), "SIN - Retracking points contains values outside of acceptable range"
 
-    assert "idx_lew_lt_max" in shared_dict, "SAR - Shared_dict does not contain 'idx_lew_lt_max'"
+    assert "idx_lew_gt_max" in shared_dict, "SAR - Shared_dict does not contain 'idx_lew_gt_max'"
 
-    idx_lew_ftype = shared_dict["idx_lew_lt_max"].dtype
+    idx_lew_ftype = shared_dict["idx_lew_gt_max"].dtype
     assert (
         "int" in str(idx_lew_ftype).lower()
-    ), f"SAR - Dtype of 'idx_lew_lt_max' is {idx_lew_ftype}, not int"
+    ), f"SAR - Dtype of 'idx_lew_gt_max' is {idx_lew_ftype}, not int"
 
 
 def test_retrack_floes_sin(
@@ -220,9 +220,9 @@ def test_retrack_floes_sin(
         & (shared_dict["floe_retracking_points"] < shared_dict["waveform"].shape[1])
     ), "SIN - Retracking points contains values outside of acceptable range"
 
-    assert "idx_lew_lt_max" in shared_dict, "SIN - Shared_dict does not contain 'idx_lew_lt_max'"
+    assert "idx_lew_gt_max" in shared_dict, "SIN - Shared_dict does not contain 'idx_lew_gt_max'"
 
-    idx_lew_ftype = shared_dict["idx_lew_lt_max"].dtype
+    idx_lew_ftype = shared_dict["idx_lew_gt_max"].dtype
     assert (
         "int" in str(idx_lew_ftype).lower()
-    ), f"SIN - Dtype of 'idx_lew_lt_max' is {idx_lew_ftype}, not int"
+    ), f"SIN - Dtype of 'idx_lew_gt_max' is {idx_lew_ftype}, not int"


### PR DESCRIPTION
Added a boolean variable for whether a sample is valid and should be used in the chain.
- Used to do this by making an elevation or retracking number a NaN, but intermediate files could be used for other research where having elevation for all samples could be useful.
- This shouldn't affect samples for trustworthy leads or floes, but ocean samples now retain elevations even if they're not used. 