### PR TITLE
Updated .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,6 @@ repos:
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports]
-        additional_dependencies: [types-all]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.


### PR DESCRIPTION
Removed types-all from mypy additional dependencies, as it's been absorbed into setuptools and removed all together. If additional dependencies are needed for mypy, I found recommendations to add only the individual packages needed which could be found by running "mypy ." when in the project folder. I ran this and it didn't come up with anything, so should be safe to assume there aren't any needed yet.